### PR TITLE
Fix build tags

### DIFF
--- a/fdset_64.go
+++ b/fdset_64.go
@@ -1,4 +1,5 @@
-// +build amd64,arm64 !darwin,!netbsd,!openbsd
+// +build amd64,arm64
+// +build !darwin,!netbsd,!openbsd
 
 package goselect
 


### PR DESCRIPTION
Hi @creack,

I tested on ARM and it seems to fix our issues

Before:
```console
(amd64 AND arm64) OR (!darwin AND !netbsd AND !openbsd)
```
After:
```console
(amd64 AND arm64) AND (!darwin AND !netbsd AND !openbsd)
```

See https://github.com/scaleway/scaleway-cli/issues/357