### PR TITLE
Preventing Select from returning an error on Windows when syscall times out

### DIFF
--- a/zselect_windows.go
+++ b/zselect_windows.go
@@ -20,8 +20,6 @@ func _select(nfds int, readfds *FDSet, writefds *FDSet, exceptfds *FDSet, timeou
 	if total == 0 {
 		if e1 != 0 {
 			err = error(e1)
-		} else {
-			err = syscall.EINVAL
 		}
 	}
 	return


### PR DESCRIPTION
This is to address #11 
According the the Miscrosoft doc, select returns 0 when a timeout occurred. This also matches what syscall does when handling select calls on Linux.