### PR TITLE
Patch TestReadWriteSync goroutine race

### DIFF
--- a/select_test.go
+++ b/select_test.go
@@ -30,7 +30,7 @@ func TestReadWriteSync(t *testing.T) {
 		time.Sleep(time.Second)
 		for i := 0; i < count; i++ {
 			fmt.Fprintf(wws[i], "hello %d", i)
-			time.Sleep(time.Millisecond)
+			time.Sleep(10*time.Millisecond)
 		}
 	}()
 


### PR DESCRIPTION
A goroutine thread in TestReadWriteSync can encounter a race condition
(pipes are populated before they are ready to be read).

This patch negligibly slows down the tests, from ~1 second to ~1.5
seconds.

Closes: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1001594 and
https://github.com/creack/goselect/issues/17 .